### PR TITLE
A non-translatable snippet breaks edit/create of this snippet

### DIFF
--- a/wagtail_localize/wagtail_hooks.py
+++ b/wagtail_localize/wagtail_hooks.py
@@ -209,7 +209,13 @@ if SNIPPET_RESTART_TRANSLATION_ENABLED:
                 enabled=False
             ).exists()
 
+    class NeverShownSnippetActionMenuItem(SnippetActionMenuItem):
+        def is_shown(self, request, context):
+            return False
+
     @hooks.register("register_snippet_action_menu_item")
     def register_restart_translation_snippet_action_menu_item(model):
         if issubclass(model, TranslatableMixin):
             return RestartTranslationSnippetActionMenuItem(order=0)
+        else:
+            return NeverShownSnippetActionMenuItem()


### PR DESCRIPTION
This is a hotfix for #265. 
Using a dummy class to avoid returning `None`.